### PR TITLE
AE-1368: Fix and redeploy multi-sig bot

### DIFF
--- a/multisig-transactions-monitor/package.json
+++ b/multisig-transactions-monitor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forta-compound-finance-multisig-transaction-bot",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Forta Bot monitoring transactions for the Compound Finance Community Multisig Contract",
   "chainIds": [
     1

--- a/multisig-transactions-monitor/src/agent.spec.js
+++ b/multisig-transactions-monitor/src/agent.spec.js
@@ -191,7 +191,7 @@ describe('monitor multisig contract transactions', () => {
       mockTxEvent = createTransactionEvent({});
     });
 
-    it('returns empty findings if multisig was not involved in a a tranasction', async () => {
+    it('returns empty findings if multisig was not involved in a a transaction', async () => {
       mockTxEvent.addresses[ethers.constants.AddressZero] = true;
       const findings = await handleTransaction(mockTxEvent);
       expect(findings).toStrictEqual([]);
@@ -283,7 +283,7 @@ describe('monitor multisig contract transactions', () => {
 
       const findings = await handleTransaction(mockTxEvent);
       const expectedFindings = Finding.fromObject({
-        name: 'Compound New Adimn',
+        name: 'Compound New Admin',
         description: `Governance Admin changed from ${zeroAddress} to ${testArgumentAddress}`,
         alertId: 'AE-COMP-GOVERNANCE-NEW-ADMIN-ALERT',
         protocol: 'Compound',

--- a/multisig-transactions-monitor/src/utils.js
+++ b/multisig-transactions-monitor/src/utils.js
@@ -221,7 +221,7 @@ function createNewAdminFinding(
   const { oldAdmin, newAdmin } = log.args;
 
   const finding = Finding.fromObject({
-    name: `${protocolName} New Adimn`,
+    name: `${protocolName} New Admin`,
     description: `Governance Admin changed from ${oldAdmin} to ${newAdmin}`,
     alertId: `${developerAbbreviation}-${protocolAbbreviation}-GOVERNANCE-NEW-ADMIN-ALERT`,
     protocol: protocolName,

--- a/multisig-transactions-monitor/src/utils.js
+++ b/multisig-transactions-monitor/src/utils.js
@@ -280,7 +280,7 @@ function createGovernanceFinding(
     );
   }
 
-  if (log.name === 'ProposalThresHoldSet') {
+  if (log.name === 'ProposalThresholdSet') {
     finding = createProposalThresholdSetFinding(
       log,
       protocolName,
@@ -382,7 +382,7 @@ function createNewBorrowCapFinding(
   return finding;
 }
 
-function createNewBorrowCapGaurdianFinding(
+function createNewBorrowCapGuardianFinding(
   log,
   protocolName,
   protocolAbbreviation,
@@ -415,7 +415,7 @@ function createComptrollerFinding(
   let finding;
 
   if (log.name === 'NewBorrowCapGuardian') {
-    finding = createNewBorrowCapGaurdianFinding(
+    finding = createNewBorrowCapGuardianFinding(
       log,
       protocolName,
       protocolAbbreviation,


### PR DESCRIPTION
There were two small issues that needed to be addressed:
- The event name `ProposalThresholdSet` was used in a switch statement for filtering which event the contract emitted.  Unfortunately, the string had a capital `H` in it in the `case` statement, which would have prevented that case from ever being executed (it would have dropped through to the default case).
- There is a function name with the word `Guardian` misspelled.