### PR TITLE
AE-1407: Check liquidity in low liquidity bot

### DIFF
--- a/low-liquidity-market-attack-monitor/src/agent.js
+++ b/low-liquidity-market-attack-monitor/src/agent.js
@@ -49,7 +49,7 @@ function createMarketAttackAlert(
   protocolAbbreviation,
   developerAbbreviation,
   compTokenSymbol,
-  compTokenAddress,
+  cTokenAddress,
   mintAmount,
   mintTokens,
   maliciousAddress,
@@ -64,7 +64,7 @@ function createMarketAttackAlert(
     protocol: protocolName,
     metadata: {
       compTokenSymbol,
-      compTokenAddress,
+      cTokenAddress,
       mintAmount,
       mintTokens,
       maliciousAddress,
@@ -81,13 +81,13 @@ async function getCompoundTokens(
   excludeAddresses,
   compTokens,
 ) {
-  let compTokenAddresses = await comptrollerContract.getAllMarkets();
-  compTokenAddresses = compTokenAddresses
+  let cTokenAddresses = await comptrollerContract.getAllMarkets();
+  cTokenAddresses = cTokenAddresses
     .map((addr) => addr.toLowerCase())
     .filter((addr) => excludeAddresses.indexOf(addr) === -1)
     .filter((addr) => !Object.keys(compTokens).includes(addr));
 
-  await Promise.all(compTokenAddresses.map(async (tokenAddress) => {
+  await Promise.all(cTokenAddresses.map(async (tokenAddress) => {
     const contract = new ethers.Contract(tokenAddress, compTokenAbi, provider);
     const symbol = await contract.symbol();
     const underlying = await contract.underlying();
@@ -96,6 +96,7 @@ async function getCompoundTokens(
     compTokens[tokenAddress] = {
       symbol,
       underlying: underlying.toLowerCase(),
+      contract,
     };
   }));
 }
@@ -152,7 +153,6 @@ function provideHandleTransaction(data) {
       compTokenAbi,
       comptrollerContract,
     } = data;
-    const findings = [];
 
     await getCompoundTokens(
       provider,
@@ -170,31 +170,63 @@ function provideHandleTransaction(data) {
     // - The Transfer event was emitted by the underlying token contract
     //    corresponding to that Compound cToken contract and
     //    was being transferred directly to said Compound cToken contract
-    transferEvents.forEach((transferEvent) => {
-      Object.entries(compTokens).forEach(([compTokenAddress, compToken]) => {
-        if (transferEvent.address === compToken.underlying
-          && transferEvent.args.to.toLowerCase() === compTokenAddress) {
-          filterLog(txEvent.logs, CERC20_MINT_EVENT, compTokenAddress)
-            .forEach((mintEvent) => {
-              if (transferEvent.logIndex > mintEvent.logIndex) {
-                findings.push(createMarketAttackAlert(
-                  protocolName,
-                  protocolAbbreviation,
-                  developerAbbreviation,
-                  compToken.symbol,
-                  transferEvent.args.to,
-                  mintEvent.args.mintAmount.toString(),
-                  mintEvent.args.mintTokens.toString(),
-                  transferEvent.args.from,
-                  transferEvent.args.amount.toString(),
-                ));
-              }
-            });
+    // - The amount being minted is significant compared to the current total supply
+    const transferPromises = transferEvents.map(async (transferEvent) => {
+      const tokenPromises = Object.entries(compTokens).map(async ([cTokenAddress, compToken]) => {
+        const { symbol, underlying, contract } = compToken;
+
+        if (transferEvent.address.toLowerCase() !== underlying.toLowerCase()) {
+          return [];
         }
+
+        if (transferEvent.args.to.toLowerCase() !== cTokenAddress.toLowerCase()) {
+          return [];
+        }
+
+        const mintEvents = txEvent.filterLog(CERC20_MINT_EVENT, cTokenAddress);
+        const mintPromises = mintEvents.map(async (mintEvent) => {
+          if (transferEvent.logIndex < mintEvent.logIndex) {
+            return [];
+          }
+
+          // check that the amount being minted is significant compared to the current total supply
+          // total supply is the number of tokens in circulation for the market
+          console.log(contract);
+          const totalSupply = await contract.totalSupply();
+          const { mintTokens } = mintEvent.args;
+
+          // if the market has a significant amount of liquidity, the attacker would need to
+          // mint a considerable number of cTokens to make the attack worthwhile
+          // threshold: if the number of minted tokens is greater than 10% of the total supply
+          if (mintTokens.mul(10).gt(totalSupply)) {
+            // create finding
+            return [
+              createMarketAttackAlert(
+                protocolName,
+                protocolAbbreviation,
+                developerAbbreviation,
+                symbol,
+                transferEvent.args.to,
+                mintEvent.args.mintAmount.toString(),
+                mintEvent.args.mintTokens.toString(),
+                transferEvent.args.from,
+                transferEvent.args.amount.toString(),
+              ),
+            ];
+          }
+          return [];
+        });
+
+        const mintResults = await Promise.all(mintPromises);
+        return mintResults.flat();
       });
+
+      const tokenResults = await Promise.all(tokenPromises);
+      return tokenResults.flat();
     });
 
-    return findings;
+    const transferResults = await Promise.all(transferPromises);
+    return transferResults.flat();
   };
 }
 

--- a/low-liquidity-market-attack-monitor/src/agent.js
+++ b/low-liquidity-market-attack-monitor/src/agent.js
@@ -191,7 +191,6 @@ function provideHandleTransaction(data) {
 
           // check that the amount being minted is significant compared to the current total supply
           // total supply is the number of tokens in circulation for the market
-          console.log(contract);
           const totalSupply = await contract.totalSupply();
           const { mintTokens } = mintEvent.args;
 

--- a/low-liquidity-market-attack-monitor/src/agent.js
+++ b/low-liquidity-market-attack-monitor/src/agent.js
@@ -54,6 +54,7 @@ function createMarketAttackAlert(
   mintTokens,
   maliciousAddress,
   maliciousAmount,
+  totalSupply,
 ) {
   const finding = Finding.fromObject({
     name: `${protocolName} cToken Market Attack Event`,
@@ -69,6 +70,7 @@ function createMarketAttackAlert(
       mintTokens,
       maliciousAddress,
       maliciousAmount,
+      totalSupply,
     },
   });
   return finding;
@@ -210,6 +212,7 @@ function provideHandleTransaction(data) {
                 mintEvent.args.mintTokens.toString(),
                 transferEvent.args.from,
                 transferEvent.args.amount.toString(),
+                totalSupply.toString(),
               ),
             ];
           }

--- a/low-liquidity-market-attack-monitor/src/agent.spec.js
+++ b/low-liquidity-market-attack-monitor/src/agent.spec.js
@@ -107,6 +107,7 @@ describe('test createMarketAttackAlert', () => {
   let mintTokens;
   let maliciousAddress;
   let maliciousAmount;
+  let totalSupply;
 
   beforeAll(async () => {
     protocolName = config.protocolName;
@@ -132,6 +133,7 @@ describe('test createMarketAttackAlert', () => {
         mintTokens,
         maliciousAddress,
         maliciousAmount,
+        totalSupply,
       },
     });
 
@@ -145,6 +147,7 @@ describe('test createMarketAttackAlert', () => {
       mintTokens,
       maliciousAddress,
       maliciousAmount,
+      totalSupply,
     );
 
     expect(finding).toStrictEqual(expectedFinding);
@@ -296,6 +299,7 @@ describe('monitor compound for attacks on cToken markets', () => {
         mintTokens,
         validAttackAddress,
         maliciousAmount,
+        validTotalSupply.toString(),
       );
 
       expect(findings).toStrictEqual([expectedFinding]);
@@ -369,6 +373,7 @@ describe('monitor compound for attacks on cToken markets', () => {
         mintTokens,
         validAttackAddress,
         maliciousAmount,
+        validTotalSupply.toString(),
       );
 
       expect(findings).toStrictEqual([expectedFinding]);


### PR DESCRIPTION
The heuristic that we use for this Bot checks all of the conditions for an attack carried out on a Compound market with low liquidity...except for verifying that the market has low liquidity compared to the size of the attack.

This pull request is to add a check for the size of the potential attack against the total supply of the Compound market being used.  The threshold is set at 1/10th of the total supply, which is quite conservative, as an attacker would effectively be splitting the proceeds of an attack with all other suppliers in the Compound market.

The deployed Bot triggered on the following transaction, which the new logic should prevent:
`npm run tx 0x5c573ac5a98d1d7856ee90d19821e50f56742b43c756d319e65bd55df0dd7a44`