### PR TITLE
AE-1426: Perform Discord POST retries based on Retry-After value in 429 Response

### DIFF
--- a/defender/package.json
+++ b/defender/package.json
@@ -2,6 +2,9 @@
   "name": "defender-compound-monitoring",
   "version": "1.0.0",
   "description": "",
+  "jest": {
+    "testTimeout": 50000
+  },
   "scripts": {
     "download": "node download.js",
     "deploy": "node deploy.js",

--- a/defender/staged/downloaded/Forta_Liquidation_Monitor.js
+++ b/defender/staged/downloaded/Forta_Liquidation_Monitor.js
@@ -27,9 +27,30 @@ async function postToDiscord(url, message) {
     // check if this is a "too many requests" error (HTTP status 429)
     if (error.response && error.response.status === 429) {
       // the request was made and a response was received
-      // try again after waiting 5 seconds
+      // try again after waiting 5 - 50 seconds, if retry_after value is received, use that.
+      let timeout;
+      // Discord Webhook API defaults to v6, and v6 returns retry_after value in ms. Later versions
+      // use seconds, so this will need to be updated when Discord changes their default API version
+      // Ref: https://discord.com/developers/docs/reference
+      if (error.response.data
+        && error.response.data.retry_after
+        && error.response.data.retry_after < 50000) {
+        // Wait the specified amount of time + a random number to reduce
+        // overlap with newer requests. Initial testing reveals that the Discord Webhook allows 5
+        // requests and then resets the counter after 2 seconds. With a 15 second range of 5-20,
+        // this function can reliably can handle batches of 15 requests. Increase the max variable
+        // below if you anticipate a larger number of requests.
+        // Ref: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/random
+        const min = 5000;
+        const max = 30000;
+        timeout = Math.floor(Math.random() * (max - min) + min);
+        timeout += error.response.data.retry_after;
+      } else {
+        // If retry_after is larger than 50 seconds, then just wait 50 seconds.
+        timeout = 50000;
+      }
       // eslint-disable-next-line no-promise-executor-return
-      const promise = new Promise((resolve) => setTimeout(resolve, 5000));
+      const promise = new Promise((resolve) => setTimeout(resolve, timeout));
       await promise;
       response = await post(url, method, headers, data);
     } else {


### PR DESCRIPTION
Since this only affects autotasks. I will merge this into my autotask branch AE-1426.

Testing: To test it out, create an `.env` file with your webhook `discordUrl = ""` then you can test them from the `defender` folder with `npm test staged/downloaded/`. This should successfully generate 28 discord messages. 

Previously in AE-1406, this would fail to post more than half with a 429 error. 

Additional info:
Discord allows 5 Webhook calls every 2 seconds. Discord also replies back with a `retry-after` value. Which is how long you should wait before trying again. This value would mostly be useful if you only needed to make 1 call. It does not take into account any previous nor future calls. Example1: I make 30 requests, 5 go through, the remaining 25 return with error 429 and a `retry-after` value ranging from 0.1 to 1.5. If I attempt to resend the 25 requests at that specified time, my counter will not have been reset, and all 25 requests will return with error 429. 

`retry-after` is odd. Generally for each batch of requests, the values are closely grouped within 2 seconds of each other. But the actual values that I've seen range from 0 seconds to 45 seconds. If one request is receives a `retry-after` value of 30, then it's expected that all other requests send at that time will also receive 29-31 second wait times. This value might be more related to how busy the Discord server is rather than trying to keep you withing your rate-limit. If you hammer the server with requests, this value does go up, but settles back to near zero after about 2 minutes. 

The solution: 
Wait the recommended `retry-after` time, but also add random wait time of 5 seconds to X so that your secondary attempts don't accidently overlap 5 requests in a 2 second window. To handle even more requests, the random window can be easily increased. Alternatively, this can be coded for more retries (not implemented).