### PR TITLE
AE-1838 Fix Compound Autotask Forta Explorer Queries

### DIFF
--- a/defender/staged/downloaded/Autotask_Forta_Explorer_Monitor.js
+++ b/defender/staged/downloaded/Autotask_Forta_Explorer_Monitor.js
@@ -162,59 +162,60 @@ function parseMetricsResponse(response, currentTimestamp) {
 function createAlertsQuery(botId, currentTimestamp, lastUpdateTimestamp) {
   const graphqlQuery = {
     operationName: 'Retrieve',
-    query: `query Retrieve($getListInput: GetAlertsInput) {
+    query: `query Retrive($getListInput: GetAlertsInput) {
       getList(input: $getListInput) {
-        alerts {
-          hash
-          description
-          severity
-          protocol
-          name
-          everest_id
-          alert_id
-          scanner_count
-          source {
-            tx_hash
-            agent {
-              id
-              name
-            }
-            block {
-              chain_id
-              number
-              timestamp
-            }
+        aggregations {
+          severity {
+            key
+            doc_count
+            __typename
           }
-          projects {
-            id
-            name
+          alerts {
+            key
+            doc_count
+            __typename
           }
+          agents {
+            key
+            doc_count
+            __typename
+          }
+          interval {
+            key
+            doc_count
+            __typename
+          }
+          cardinalities {
+            agents
+            alerts
+            __typename
+          }
+          __typename
         }
-        nextPageValues {
-          blocknumber
-          id
-        }
-        currentPageValues {
-          blocknumber
-          id
-        }
+        __typename
       }
-    }`,
-    variables: {
+    }
+    `,
+    variable: {
       getListInput: {
         severity: [],
+        agents: [botId],
+        txHash: "",
+        text: "",
+        muted: [],
+        sort: "",
+        limit: 0,
+        project: "",
         startDate: (lastUpdateTimestamp + 1).toString(),
         endDate: currentTimestamp.toString(),
-        txHash: '',
-        text: '',
-        muted: [],
-        limit: 0,
-        sort: 'desc',
-        agents: [botId],
-        addresses: [],
-        project: '',
-      },
-    },
+        aggregations: {
+          severity: true,
+          interval: "day",
+          alerts: 6,
+          cardinalities:true
+        }
+      }
+    }
   };
   return graphqlQuery;
 }

--- a/defender/staged/downloaded/Autotask_Forta_Explorer_Monitor.js
+++ b/defender/staged/downloaded/Autotask_Forta_Explorer_Monitor.js
@@ -90,7 +90,7 @@ function parseAlertsResponse(response) {
     };
   }
 
-  const { data: { data: { getList: { alerts } } } } = response;
+  const { data: { data: { getList: { aggregations: { alerts } } } } } = response;
   const newAlerts = alerts.map((alert) => {
     const output = {};
     Object.entries(alert).forEach(([key, value]) => {

--- a/defender/staged/downloaded/Autotask_Forta_Explorer_Monitor.js
+++ b/defender/staged/downloaded/Autotask_Forta_Explorer_Monitor.js
@@ -52,8 +52,7 @@ function parseAgentInformationResponse(response) {
 
   const output = {};
   Object.entries(getAgentInformation[0]).forEach(([key, value]) => {
-    const newKey = camelize(key, '_');
-    output[newKey] = value;
+    output[camelize(key, '_')] = value
   });
 
   return output;
@@ -133,7 +132,7 @@ function createAlertsQuery(botId, currentTimestamp, lastUpdateTimestamp) {
         }
       }
     }`,
-    variable: {
+    variables: {
       getListInput: {
         agents: [botId],
         limit: 100,
@@ -153,7 +152,7 @@ function createAlertsQuery(botId, currentTimestamp, lastUpdateTimestamp) {
 function createAgentInformationQuery(id) {
   const graphqlQuery = {
     operationName: 'Retrieve',
-    query: `query Retrive($getAgentInput: AgentInformation) {
+    query: `query Retrieve($getAgentInput: AgentInformation) {
       getAgentInformation(input: $getAgentInput) {
         id
         name
@@ -169,7 +168,6 @@ function createAgentInformationQuery(id) {
         image
         manifest_ipfs
         doc_ipfs
-        __typename
       }
     }`,
     variables: {
@@ -222,6 +220,7 @@ async function postQuery(graphqlQuery) {
     data: graphqlQuery,
   });
 
+  console.debug("look here for response", response.data)
   return response;
 }
 

--- a/defender/staged/downloaded/Autotask_Forta_Explorer_Monitor.js
+++ b/defender/staged/downloaded/Autotask_Forta_Explorer_Monitor.js
@@ -162,7 +162,7 @@ function parseMetricsResponse(response, currentTimestamp) {
 function createAlertsQuery(botId, currentTimestamp, lastUpdateTimestamp) {
   const graphqlQuery = {
     operationName: 'Retrieve',
-    query: `query Retrive($getListInput: GetAlertsInput) {
+    query: `query Retrieve($getListInput: GetAlertsInput) {
       getList(input: $getListInput) {
         aggregations {
           severity {

--- a/defender/staged/downloaded/Autotask_Forta_Explorer_Monitor.spec.js
+++ b/defender/staged/downloaded/Autotask_Forta_Explorer_Monitor.spec.js
@@ -48,7 +48,7 @@ describe('Run the Autotask', () => {
     const alerts = [];
     const metrics = [];
     const getAgentInformation = [{}];
-    const mockAlertResponse = { data: { data: { getList: { alerts } } } };
+    const mockAlertResponse = { data: { data: { getList: { aggregations: { alerts } } } } };
     const mockMetricsResponse = { data: { data: { getAgentMetrics: { metrics } } } };
     const mockAgentInformationResponse = { data: { data: { getAgentInformation } } };
     axios.mockImplementation((inputObject) => {
@@ -107,7 +107,7 @@ describe('Run the Autotask', () => {
 
     const alerts = [];
     const metrics = [];
-    const mockAlertResponse = { data: { data: { getList: { alerts } } } };
+    const mockAlertResponse = { data: { data: { getList: { aggregations: { alerts } } } } };
     const mockMetricsResponse = { data: { data: { getAgentMetrics: { metrics } } } };
     axios.mockImplementation((inputObject) => {
       const { data: { query } } = inputObject;
@@ -166,7 +166,7 @@ describe('Run the Autotask', () => {
 
     const alerts = [];
     const metrics = [];
-    const mockAlertResponse = { data: { data: { getList: { alerts } } } };
+    const mockAlertResponse = { data: { data: { getList: { aggregations: { alerts } } } } };
     const mockMetricsResponse = { data: { data: { getAgentMetrics: { metrics } } } };
     axios.mockImplementation((inputObject) => {
       const { data: { query } } = inputObject;
@@ -259,7 +259,7 @@ describe('Run the Autotask', () => {
     ];
 
     const getAgentInformation = [{}];
-    const mockAlertResponse = { data: { data: { getList: { alerts } } } };
+    const mockAlertResponse = { data: { data: { getList: { aggregations: { alerts } } } } };
     const mockMetricsResponse = { data: { data: { getAgentMetrics: { metrics } } } };
     const mockAgentInformationResponse = { data: { data: { getAgentInformation } } };
     axios.mockImplementation((inputObject) => {
@@ -334,7 +334,7 @@ describe('Run the Autotask', () => {
 
     const metrics = [];
     const getAgentInformation = [{}];
-    const mockAlertResponse = { data: { data: { getList: { alerts } } } };
+    const mockAlertResponse = { data: { data: { getList: { aggregations: { alerts } } } } };
     const mockMetricsResponse = { data: { data: { getAgentMetrics: { metrics } } } };
     const mockAgentInformationResponse = { data: { data: { getAgentInformation } } };
     axios.mockImplementation((inputObject) => {

--- a/defender/staged/downloaded/Autotask_Forta_Explorer_Monitor.spec.js
+++ b/defender/staged/downloaded/Autotask_Forta_Explorer_Monitor.spec.js
@@ -53,7 +53,7 @@ describe('Run the Autotask', () => {
     const mockAgentInformationResponse = { data: { data: { getAgentInformation } } };
     axios.mockImplementation((inputObject) => {
       const { data: { query } } = inputObject;
-      if (query.includes('alert_id')) {
+      if (query.includes('GetAlertsInput')) {
         return mockAlertResponse;
       }
 
@@ -111,7 +111,7 @@ describe('Run the Autotask', () => {
     const mockMetricsResponse = { data: { data: { getAgentMetrics: { metrics } } } };
     axios.mockImplementation((inputObject) => {
       const { data: { query } } = inputObject;
-      if (query.includes('alert_id')) {
+      if (query.includes('GetAlertsInput')) {
         return mockAlertResponse;
       }
 
@@ -170,7 +170,7 @@ describe('Run the Autotask', () => {
     const mockMetricsResponse = { data: { data: { getAgentMetrics: { metrics } } } };
     axios.mockImplementation((inputObject) => {
       const { data: { query } } = inputObject;
-      if (query.includes('alert_id')) {
+      if (query.includes('GetAlertsInput')) {
         return mockAlertResponse;
       }
 
@@ -264,7 +264,7 @@ describe('Run the Autotask', () => {
     const mockAgentInformationResponse = { data: { data: { getAgentInformation } } };
     axios.mockImplementation((inputObject) => {
       const { data: { query } } = inputObject;
-      if (query.includes('alert_id')) {
+      if (query.includes('GetAlertsInput')) {
         return mockAlertResponse;
       }
 
@@ -339,7 +339,7 @@ describe('Run the Autotask', () => {
     const mockAgentInformationResponse = { data: { data: { getAgentInformation } } };
     axios.mockImplementation((inputObject) => {
       const { data: { query } } = inputObject;
-      if (query.includes('alert_id')) {
+      if (query.includes('GetAlertsInput')) {
         return mockAlertResponse;
       }
 

--- a/defender/staged/downloaded/Autotask_Forta_Explorer_Monitor.spec.js
+++ b/defender/staged/downloaded/Autotask_Forta_Explorer_Monitor.spec.js
@@ -48,7 +48,7 @@ describe('Run the Autotask', () => {
     const alerts = [];
     const metrics = [];
     const getAgentInformation = [{}];
-    const mockAlertResponse = { data: { data: { getList: { aggregations: { alerts } } } } };
+    const mockAlertResponse = { data: { data: { getList: { alerts } } } };
     const mockMetricsResponse = { data: { data: { getAgentMetrics: { metrics } } } };
     const mockAgentInformationResponse = { data: { data: { getAgentInformation } } };
     axios.mockImplementation((inputObject) => {
@@ -107,7 +107,7 @@ describe('Run the Autotask', () => {
 
     const alerts = [];
     const metrics = [];
-    const mockAlertResponse = { data: { data: { getList: { aggregations: { alerts } } } } };
+    const mockAlertResponse = { data: { data: { getList: { alerts } } } };
     const mockMetricsResponse = { data: { data: { getAgentMetrics: { metrics } } } };
     axios.mockImplementation((inputObject) => {
       const { data: { query } } = inputObject;
@@ -166,7 +166,7 @@ describe('Run the Autotask', () => {
 
     const alerts = [];
     const metrics = [];
-    const mockAlertResponse = { data: { data: { getList: { aggregations: { alerts } } } } };
+    const mockAlertResponse = { data: { data: { getList: { alerts } } } };
     const mockMetricsResponse = { data: { data: { getAgentMetrics: { metrics } } } };
     axios.mockImplementation((inputObject) => {
       const { data: { query } } = inputObject;
@@ -259,7 +259,7 @@ describe('Run the Autotask', () => {
     ];
 
     const getAgentInformation = [{}];
-    const mockAlertResponse = { data: { data: { getList: { aggregations: { alerts } } } } };
+    const mockAlertResponse = { data: { data: { getList: { alerts } } } };
     const mockMetricsResponse = { data: { data: { getAgentMetrics: { metrics } } } };
     const mockAgentInformationResponse = { data: { data: { getAgentInformation } } };
     axios.mockImplementation((inputObject) => {
@@ -334,7 +334,7 @@ describe('Run the Autotask', () => {
 
     const metrics = [];
     const getAgentInformation = [{}];
-    const mockAlertResponse = { data: { data: { getList: { aggregations: { alerts } } } } };
+    const mockAlertResponse = { data: { data: { getList: { alerts } } } };
     const mockMetricsResponse = { data: { data: { getAgentMetrics: { metrics } } } };
     const mockAgentInformationResponse = { data: { data: { getAgentInformation } } };
     axios.mockImplementation((inputObject) => {

--- a/defender/staged/downloaded/Datadog_Alerts_Heat_Map.js
+++ b/defender/staged/downloaded/Datadog_Alerts_Heat_Map.js
@@ -79,8 +79,7 @@ function parseAlertsResponse(response) {
 // page for the Bot
 function createAlertsQuery(botId, currentTimestamp, lastUpdateTimestamp) {
   const graphqlQuery = {
-    operationName: 'Retrieve',
-    query: `query Retrieve($getListInput: GetAlertsInput) {
+    query: `query ($getListInput: GetAlertsInput) {
       getList(input: $getListInput) {
         alerts {
           hash
@@ -109,11 +108,11 @@ function createAlertsQuery(botId, currentTimestamp, lastUpdateTimestamp) {
           }
         }
         nextPageValues {
-          blocknumber
+          timestamp
           id
         }
         currentPageValues {
-          blocknumber
+          timestamp
           id
         }
       }
@@ -125,6 +124,7 @@ function createAlertsQuery(botId, currentTimestamp, lastUpdateTimestamp) {
         endDate: currentTimestamp.toString(),
         txHash: '',
         text: '',
+        limit: 100,
         muted: [],
         sort: 'desc',
         agents: [botId],
@@ -234,7 +234,7 @@ exports.handler = async function (autotaskEvent) {
   let alertsPromises = data.map(async (output) => {
     const { alerts } = output;
     if (alerts !== undefined) {
-      console.debug(JSON.stringify(alerts, null, 2));
+      console.debug("alerts here", JSON.stringify(alerts, null, 2));
       return postToDatadog({ series: alerts }, datadogApiKey, datadogApiEndpoint);
     }
     console.debug('alerts is undefined');

--- a/defender/staged/downloaded/Datadog_Alerts_Heat_Map.js
+++ b/defender/staged/downloaded/Datadog_Alerts_Heat_Map.js
@@ -79,7 +79,8 @@ function parseAlertsResponse(response) {
 // page for the Bot
 function createAlertsQuery(botId, currentTimestamp, lastUpdateTimestamp) {
   const graphqlQuery = {
-    query: `query ($getListInput: GetAlertsInput) {
+    operationName: 'Retrieve',
+    query: `query Retrieve($getListInput: GetAlertsInput) {
       getList(input: $getListInput) {
         alerts {
           hash
@@ -124,7 +125,6 @@ function createAlertsQuery(botId, currentTimestamp, lastUpdateTimestamp) {
         endDate: currentTimestamp.toString(),
         txHash: '',
         text: '',
-        limit: 100,
         muted: [],
         sort: 'desc',
         agents: [botId],
@@ -234,7 +234,7 @@ exports.handler = async function (autotaskEvent) {
   let alertsPromises = data.map(async (output) => {
     const { alerts } = output;
     if (alerts !== undefined) {
-      console.debug("alerts here", JSON.stringify(alerts, null, 2));
+      console.debug('alerts here', JSON.stringify(alerts, null, 2));
       return postToDatadog({ series: alerts }, datadogApiKey, datadogApiEndpoint);
     }
     console.debug('alerts is undefined');

--- a/defender/staged/downloaded/Datadog_Forta_Bot_Alerts.js
+++ b/defender/staged/downloaded/Datadog_Forta_Bot_Alerts.js
@@ -68,8 +68,7 @@ function parseAlertsResponse(response) {
 // page for the Bot
 function createAlertsQuery(botId, currentTimestamp, lastUpdateTimestamp) {
   const graphqlQuery = {
-    operationName: 'Retrieve',
-    query: `query Retrieve($getListInput: GetAlertsInput) {
+    query: `query ($getListInput: GetAlertsInput) {
       getList(input: $getListInput) {
         alerts {
           hash
@@ -98,11 +97,11 @@ function createAlertsQuery(botId, currentTimestamp, lastUpdateTimestamp) {
           }
         }
         nextPageValues {
-          blocknumber
+          timestamp
           id
         }
         currentPageValues {
-          blocknumber
+          timestamp
           id
         }
       }

--- a/defender/staged/downloaded/Datadog_Forta_Detection_Bot_Health.js
+++ b/defender/staged/downloaded/Datadog_Forta_Detection_Bot_Health.js
@@ -333,7 +333,7 @@ exports.handler = async function (autotaskEvent) {
         });
         return undefined;
       });
-      console.debug(JSON.stringify(series, null, 2));
+      console.debug("series data here", JSON.stringify(series, null, 2));
 
       // post to Datadog
       return postToDatadog({ series }, datadogApiKey);

--- a/defender/staged/downloaded/Datadog_Forta_Detection_Bot_Health.js
+++ b/defender/staged/downloaded/Datadog_Forta_Detection_Bot_Health.js
@@ -333,7 +333,7 @@ exports.handler = async function (autotaskEvent) {
         });
         return undefined;
       });
-      console.debug("series data here", JSON.stringify(series, null, 2));
+      console.debug('series data here', JSON.stringify(series, null, 2));
 
       // post to Datadog
       return postToDatadog({ series }, datadogApiKey);


### PR DESCRIPTION
This PR fixes 3 Autotasks that were not working in Compound's Defender account. The 3 Autotasks are:

`Autotask_Forta_Explorer_Monitor.js`
`Datadog_Alerts_Heat_Map.js`
`Datadog_Forta_Bot_Alerts.js`

The reason that they were not functioning properly was because some fields from the Forta Explorer API schema was changed, causing our Autotasks to get a 400 error every time it queried the endpoint.

You can manually test out queries in the [GraphQl sandbox](https://studio.apollographql.com/sandbox/explorer) if you would like. There is also a reference doc [here](https://arbitraryexecution.atlassian.net/wiki/spaces/GENERAL/pages/270303245/Forta+Explorer+Queries) for queries.