### PR TITLE
AE-1957: Removed protocolVersion tag.  Fixed tests to reflect new dis…

### DIFF
--- a/defender/downloaded/Forta_cToken.js
+++ b/defender/downloaded/Forta_cToken.js
@@ -136,16 +136,9 @@ exports.handler = async function (autotaskEvent) {
     cTokenSymbol,
     eventName,
     usdValue,
-    protocolVersion,
   } = metadata;
   if (usdValue === undefined) {
     throw new Error('usdValue undefined, please use newer bot version');
-  }
-
-  // Handle older alerts which don't specify the protocol version
-  let versionString = '';
-  if (protocolVersion !== undefined) {
-    versionString = ` (Compound v${protocolVersion})`;
   }
 
   const eventMapping = {
@@ -223,7 +216,6 @@ exports.handler = async function (autotaskEvent) {
   } else {
     message += ` by ${byAddress.slice(0, 6)}`;
   }
-  message += versionString;
 
   // construct the Etherscan transaction link
   const etherscanLink = `[TX](<https://etherscan.io/tx/${transactionHash}>)`;

--- a/defender/tests/Forta_cToken.spec.js
+++ b/defender/tests/Forta_cToken.spec.js
@@ -192,7 +192,7 @@ describe('check autotask', () => {
     // run the autotask on the events
     await handler(autotaskEvent);
 
-    const data = { content: `[TX](<https://etherscan.io/tx/${mockBorrowTxHash}>) 🐳📥 **$18,537 of cUSDC** borrowed by 0x8776 (Compound v2)` };
+    const data = { content: `[TX](<https://etherscan.io/tx/${mockBorrowTxHash}>) 🐳📥 **$18,537 of cUSDC** borrowed by 0x8776` };
     const expectedLastCall = {
       url, headers, method, data,
     };
@@ -211,7 +211,7 @@ describe('check autotask', () => {
     // run the autotask on the events
     await handler(autotaskEvent);
 
-    const data = { content: '[TX](<https://etherscan.io/tx/0x064228d15febb05b929e8aecbf3d828449bd8210df758d692b9b855355ed3560>) 💔 **$881 of cUSDT** liquidated from 0xf1C6 by 0xD911 (Compound v2)' };
+    const data = { content: '[TX](<https://etherscan.io/tx/0x064228d15febb05b929e8aecbf3d828449bd8210df758d692b9b855355ed3560>) 💔 **$881 of cUSDT** liquidated from 0xf1C6 by 0xD911' };
     const expectedLastCall = {
       url, headers, method, data,
     };
@@ -226,7 +226,7 @@ describe('check autotask', () => {
     // run the autotask on the events
     await handler(autotaskEvent);
 
-    const data = { content: '[TX](<https://etherscan.io/tx/0xff85476c183ef3cc0fb0623877abf5589197a773845f8acac341e48c42957a3e>) 🐳📈 **$67,721 of cETH** supplied by 0x352E (Compound v2)' };
+    const data = { content: '[TX](<https://etherscan.io/tx/0xff85476c183ef3cc0fb0623877abf5589197a773845f8acac341e48c42957a3e>) 🐳📈 **$67,721 of cETH** supplied by 0x352E' };
     const expectedLastCall = {
       url, headers, method, data,
     };
@@ -241,7 +241,7 @@ describe('check autotask', () => {
     // run the autotask on the events
     await handler(autotaskEvent);
 
-    const data = { content: '[TX](<https://etherscan.io/tx/0x881d7f5b2804d144535f7b51f504ba6bcf14f3ccd53d57f4e59e0ad262bddeb5>) 🐳📉 **$88,512 of cWBTC** withdrew by 0xF016 (Compound v2)' };
+    const data = { content: '[TX](<https://etherscan.io/tx/0x881d7f5b2804d144535f7b51f504ba6bcf14f3ccd53d57f4e59e0ad262bddeb5>) 🐳📉 **$88,512 of cWBTC** withdrew by 0xF016' };
     const expectedLastCall = {
       url, headers, method, data,
     };
@@ -260,7 +260,7 @@ describe('check autotask', () => {
     // run the autotask on the events
     await handler(autotaskEvent);
 
-    const data = { content: '[TX](<https://etherscan.io/tx/0x57a36644b7440ad247a41222ad105d5a08d21b47e434025bcf4427b2c20f3dee>) 🐳📤 **$19,985 of cUSDC** repaid by 0xF6aa (Compound v2)' };
+    const data = { content: '[TX](<https://etherscan.io/tx/0x57a36644b7440ad247a41222ad105d5a08d21b47e434025bcf4427b2c20f3dee>) 🐳📤 **$19,985 of cUSDC** repaid by 0xF6aa' };
     const expectedLastCall = {
       url, headers, method, data,
     };


### PR DESCRIPTION
It was decided that adding the `(Compound v2)` tag to the cToken monitor would be redundant because the discord messages are already sent to Compound `v2-market-feed`.  The cToken Forta bot alerts still contain the protocolVersion key in the metadata.