### PR TITLE
AE-1907: Removed defender.conf from gitleaks exclusion

### DIFF
--- a/.github/gitleaks.toml
+++ b/.github/gitleaks.toml
@@ -18,7 +18,6 @@ paths = [
   '''(.*?)\.(png|jpg|gif|doc|docx|pdf|bin|xls|pyc|zip)$''',
   '''(go.mod|go.sum)$''',
   '''(.*?)\.spec\.js$''',
-  '''(.*?)defender-config\.json$''',
 ]
 regexes = [
   '''0x[0-9a-fA-F]{40}''',


### PR DESCRIPTION
Minor PR regarding that incorrectly excluded defender.conf files